### PR TITLE
langchain.docstore no longer exists

### DIFF
--- a/mas/memory/mas_memory/GMemory.py
+++ b/mas/memory/mas_memory/GMemory.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, replace
 from langchain_chroma import Chroma
-from langchain.docstore.document import Document
+from langchain_core.documents import Document
 import os
 import copy
 import re

--- a/mas/memory/mas_memory/generative.py
+++ b/mas/memory/mas_memory/generative.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from langchain_chroma import Chroma
-from langchain.docstore.document import Document
+from langchain_core.documents import Document
 import re
 
 from .memory_base import MASMemoryBase

--- a/mas/memory/mas_memory/memorybank.py
+++ b/mas/memory/mas_memory/memorybank.py
@@ -2,7 +2,7 @@ import math
 import copy
 from dataclasses import dataclass, field
 from langchain_chroma import Chroma
-from langchain.docstore.document import Document
+from langchain_core.documents import Document
 
 from .memory_base import MASMemoryBase
 from .prompt import MEMORYBANK

--- a/mas/memory/mas_memory/metagpt.py
+++ b/mas/memory/mas_memory/metagpt.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from langchain_chroma import Chroma
-from langchain.docstore.document import Document
+from langchain_core.documents import Document
 
 from ..common import MASMessage
 from .memory_base import MASMemoryBase

--- a/mas/memory/mas_memory/voyager.py
+++ b/mas/memory/mas_memory/voyager.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from langchain_chroma import Chroma
-from langchain.docstore.document import Document
+from langchain_core.documents import Document
 
 from .memory_base import MASMemoryBase
 from .prompt import VOYAGER


### PR DESCRIPTION
Replaced `langchain.docstore.document` with `langchain_core.documents` 